### PR TITLE
Update Readme to reflect Codeql-Action-v1 deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ steps:
 # Step 3: Upload results into GitHub
 - name: Upload review result
   if: ${{ github.event_name != 'push' }}
-  uses: github/codeql-action/upload-sarif@v2
+  uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: codeguru-results.sarif.json
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ steps:
 # Step 3: Upload results into GitHub
 - name: Upload review result
   if: ${{ github.event_name != 'push' }}
-  uses: github/codeql-action/upload-sarif@v1
+  uses: github/codeql-action/upload-sarif@v2
   with:
     sarif_file: codeguru-results.sarif.json
 ```


### PR DESCRIPTION
https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

*Issue #, if available:*

*Description of changes:*

- Updated readme setup to reference github/codeql-action/upload-sarif@v2  since v1 has been deprecated and now leads to build errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
